### PR TITLE
Do not call getCredentials method because it initializes the default credentials.

### DIFF
--- a/tcdeps-groovy/src/test/groovy/com/github/jk1/tcdeps/TeamCityRepoSpec.groovy
+++ b/tcdeps-groovy/src/test/groovy/com/github/jk1/tcdeps/TeamCityRepoSpec.groovy
@@ -1,6 +1,6 @@
 package com.github.jk1.tcdeps
 
-
+import com.github.jk1.tcdeps.util.ResourceLocator
 import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.testfixtures.ProjectBuilder
@@ -32,6 +32,7 @@ class TeamCityRepoSpec extends Specification {
 
         then:
         project.repositories.findByName("TeamCity").getUrl() == new URI("http://teamcity/guestAuth/repository/download")
+        ResourceLocator.credentials == null
     }
 
     def "teamcity repository should use http auth when credentials are provided"() {
@@ -49,6 +50,7 @@ class TeamCityRepoSpec extends Specification {
 
         then:
         project.repositories.findByName("TeamCity").getUrl() == new URI("http://teamcity/httpAuth/repository/download")
+        ResourceLocator.credentials != null
     }
 
 

--- a/tcdeps-kt/build.gradle
+++ b/tcdeps-kt/build.gradle
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '2.2.20'
 }
@@ -12,10 +15,20 @@ dependencies {
     implementation localGroovy()
 
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.2.20'
+
+    testImplementation gradleTestKit()
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.14.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.14.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.0'
 }
 
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = '11'
+test {
+    useJUnitPlatform()
+    jvmArgs = ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
+}
+
+tasks.withType(KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
     }
 }

--- a/tcdeps-kt/src/main/kotlin/com/github/jk1/tcdeps/KotlinScriptDslAdapter.kt
+++ b/tcdeps-kt/src/main/kotlin/com/github/jk1/tcdeps/KotlinScriptDslAdapter.kt
@@ -9,7 +9,8 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
-import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository
 
 object KotlinScriptDslAdapter {
 
@@ -18,7 +19,7 @@ object KotlinScriptDslAdapter {
         val plugin = project.getOurPlugin()
         val repositories = project.repositories
         val oldRepo = repositories.findByName("TeamCity") as IvyArtifactRepository?
-        val repo = plugin.createTeamCityRepository(project)
+        val repo = plugin.createTeamCityRepository(project) as DefaultIvyArtifactRepository
         action(repo)
         if (repo.url == null) {
             throw GradleException("TeamCity repository url shouldn't be null")
@@ -32,8 +33,8 @@ object KotlinScriptDslAdapter {
         val tcUrl = repo.url.toString()
         val normalizeTcUrl = if (tcUrl.endsWith('/')) tcUrl else "$tcUrl/"
 
-        if (repo.credentials.username.orEmpty().isBlank() && repo.credentials.password.orEmpty().isBlank()) {
-            (repo as AuthenticationSupportedInternal).setConfiguredCredentials(null)
+        val configuredCredentials = repo.configuredCredentials.map { it as? PasswordCredentials }.orNull
+        if (configuredCredentials?.username.isNullOrBlank() && configuredCredentials?.password.isNullOrBlank()) {
             repo.setUrl("${normalizeTcUrl}guestAuth/repository/download")
         } else {
             repo.setUrl("${normalizeTcUrl}httpAuth/repository/download")

--- a/tcdeps-kt/src/test/kotlin/com/github/jk1/tcdeps/KotlinScriptDslAdapterTest.kt
+++ b/tcdeps-kt/src/test/kotlin/com/github/jk1/tcdeps/KotlinScriptDslAdapterTest.kt
@@ -1,0 +1,96 @@
+package com.github.jk1.tcdeps
+
+import com.github.jk1.tcdeps.KotlinScriptDslAdapter.pin
+import com.github.jk1.tcdeps.KotlinScriptDslAdapter.teamcityServer
+import com.github.jk1.tcdeps.util.ResourceLocator
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class KotlinScriptDslAdapterTest {
+
+    private lateinit var project: Project
+
+    @BeforeEach
+    fun setUp() {
+        project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.github.jk1.tcdeps")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ResourceLocator.closeResourceLocator()
+    }
+
+    @Test
+    fun `teamcity repository should use guest auth urls when no username is available`() {
+        project.repositories.teamcityServer {
+            url = URI("http://teamcity")
+        }
+
+        val repo = project.repositories.findByName("TeamCity") as IvyArtifactRepository
+        assertEquals(URI("http://teamcity/guestAuth/repository/download"), repo.url)
+        assertNull(ResourceLocator.getCredentials())
+    }
+
+    @Test
+    fun `teamcity repository should use http auth when credentials are provided`() {
+        project.repositories.teamcityServer {
+            url = URI("http://teamcity")
+            credentials {
+                it.username = "name"
+                it.password = "secret"
+            }
+        }
+
+        val repo = project.repositories.findByName("TeamCity") as IvyArtifactRepository
+        assertEquals(URI("http://teamcity/httpAuth/repository/download"), repo.url)
+        assertNotNull(ResourceLocator.getCredentials())
+    }
+
+    @Test
+    fun `teamcity repository should support pin configuration`() {
+        project.repositories.teamcityServer {
+            url = URI("http://teamcity")
+            credentials {
+                it.username = "name"
+                it.password = "secret"
+            }
+            pin {
+                stopBuildOnFail = true
+                message = "Pinned for MyCoolProject"
+            }
+        }
+
+        val repo = project.repositories.findByName("TeamCity") as IvyArtifactRepository
+        assertEquals("http://teamcity/httpAuth/repository/download", repo.url.toString())
+        assertEquals("name", repo.credentials.username)
+        assertEquals("secret", repo.credentials.password)
+        val pinConfig = ResourceLocator.getConfig()
+        assertTrue(pinConfig.pinEnabled)
+        assertEquals("Pinned for MyCoolProject", pinConfig.message)
+        assertTrue(pinConfig.stopBuildOnFail)
+    }
+
+    @Test
+    fun `should maintain only one TeamCity server`() {
+        project.repositories.teamcityServer {
+            url = URI("http://teamcity1")
+        }
+        project.repositories.teamcityServer {
+            url = URI("http://teamcity2")
+        }
+
+        val repos = project.repositories.filterIsInstance<IvyArtifactRepository>()
+        assertEquals(1, repos.size)
+        assertTrue(repos[0].url.toString().contains("teamcity2"))
+    }
+}


### PR DESCRIPTION
The line `(repo as AuthenticationSupportedInternal).setConfiguredCredentials(null)` sets [usesCredentials](https://github.com/gradle/gradle/blob/878f0f5a4c4dacb799ced1d5a9dd6e07f9b23625/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java#L93) flag to true. After that, when `getConfiguredAuthentication` is called, it causes [credentials.get()](https://github.com/gradle/gradle/blob/878f0f5a4c4dacb799ced1d5a9dd6e07f9b23625/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java#L123) to be called. And that produces an exception:
```
Caused by: org.gradle.api.internal.provider.MissingValueException: Cannot query the value of this property because it has no value available.
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateOwnPresentValue(AbstractMinimalProvider.java:82)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.get(AbstractMinimalProvider.java:100)
	at org.gradle.api.internal.artifacts.repositories.AuthenticationSupporter.getConfiguredAuthentication(AuthenticationSupporter.java:123)
	at org.gradle.api.internal.artifacts.repositories.AbstractAuthenticationSupportedRepository.getConfiguredAuthentication(AbstractAuthenticationSupportedRepository.java:107)
...
```

We have to explicitly call `(repo as AuthenticationSupportedInternal).setConfiguredCredentials(null)` because previously we accessed `repo.credentials` and that access initializes the default credentials. The proposed solution is to use `configuredCredentials` instead of `credentials` to check if the credentials are set.

Maybe there is a better way to work with `credentials`/`configuredCredentials`, but I try to keep the Kotlin DSL compatible with the Groove, where `ResourceLocator.credentials` returns null in case of skipped credentials.